### PR TITLE
Fix cooked tag "rpg_series:tier_2_armors"

### DIFF
--- a/src/main/resources/data/rpg_series/tags/items/tier_2_armors.json
+++ b/src/main/resources/data/rpg_series/tags/items/tier_2_armors.json
@@ -1,17 +1,17 @@
 {
   "replace": false,
   "values": [
-    "spellbladenext:runeblaze_head",
-    "spellbladenext:runeblaze_chest",
-    "spellbladenext:runeblaze_legs",
-    "spellbladenext:runeblaze_feet",
-    "spellbladenext:runegleam_head",
-    "spellbladenext:runegleam_chest",
-    "spellbladenext:runegleam_legs",
-    "spellbladenext:runegleam_feet",
-    "spellbladenext:runefrost_head",
-    "spellbladenext:runefrost_chest",
-    "spellbladenext:runefrost_legs",
-    "spellbladenext:runefrost_feet"
+    "spellbladenext:runeblazing_head",
+    "spellbladenext:runeblazing_chest",
+    "spellbladenext:runeblazing_legs",
+    "spellbladenext:runeblazing_feet",
+    "spellbladenext:runegleaming_head",
+    "spellbladenext:runegleaming_chest",
+    "spellbladenext:runegleaming_legs",
+    "spellbladenext:runegleaming_feet",
+    "spellbladenext:runefrosted_head",
+    "spellbladenext:runefrosted_chest",
+    "spellbladenext:runefrosted_legs",
+    "spellbladenext:runefrosted_feet"
   ]
 }


### PR DESCRIPTION
Title. Fixes misspelled item IDs in the `rpg_series:tier_2_armors` item tag.

![image](https://github.com/user-attachments/assets/ab2ff360-f045-4e2e-a2d7-3447adc9c937)
![image](https://github.com/user-attachments/assets/b47f52c1-abbf-41a0-aa69-c6f33d7c69c1)
